### PR TITLE
feat: implement .runxrc config file support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,6 +1417,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util",
+ "toml",
  "zip",
 ]
 
@@ -1563,6 +1564,15 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1846,6 +1856,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -2267,6 +2318,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ sha2 = "0.10"
 tar = "0.4"
 tempfile = "3"
 thiserror = "2"
+toml = "0.8"
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["io"] }
 futures-util = "0.3"

--- a/README.md
+++ b/README.md
@@ -83,6 +83,26 @@ By default, runx creates a clean, isolated environment. Use `--inherit-env` to p
 runx --with node@18 --inherit-env -- node -v
 ```
 
+### Project config with `.runxrc`
+
+Instead of passing `--with` flags every time, create a `.runxrc` file in your project root:
+
+```toml
+tools = ["node@18", "python@3.11"]
+inherit_env = true
+```
+
+runx automatically discovers `.runxrc` by searching the current directory and walking up parent directories. CLI `--with` flags override tools specified in the config file.
+
+Use `--dry-run` or `--verbose` to see which config file was loaded:
+
+```bash
+runx --dry-run -- node -v
+# Shows: loaded config from /path/to/project/.runxrc
+```
+
+Scaffold a new config file with `runx init`.
+
 ### Cache management
 
 ```bash
@@ -123,6 +143,7 @@ With `--inherit-env`, the full user environment is kept and tool paths are prepe
 src/
   main.rs          Entry point (tokio async)
   cli.rs           CLI parsing (clap derive)
+  config.rs        .runxrc TOML config file discovery and parsing
   run.rs           Orchestration: resolve -> download -> env -> execute
   cache.rs         ~/.runx/cache/ management
   download.rs      Streaming HTTP download + archive extraction

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,295 @@
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use crate::cli::ToolSpec;
+
+/// The `.runxrc` config file name.
+const CONFIG_FILE_NAME: &str = ".runxrc";
+
+/// Parsed `.runxrc` configuration.
+#[derive(Debug, Clone, Default)]
+pub struct Config {
+    /// Path to the config file that was loaded (None if no config found).
+    pub source: Option<PathBuf>,
+    /// Tool specs from the config file.
+    pub tools: Vec<ToolSpec>,
+    /// Whether to inherit the user's full environment.
+    pub inherit_env: Option<bool>,
+}
+
+/// Raw TOML structure matching the `.runxrc` file format.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawConfig {
+    /// Tools in `name@version` format.
+    tools: Option<Vec<String>>,
+    /// Whether to inherit the user's full environment.
+    inherit_env: Option<bool>,
+}
+
+/// Errors that occur during config file operations.
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigError {
+    #[error("failed to read config `{}`: {source}", path.display())]
+    Read {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[error("failed to parse config `{}`: {reason}", path.display())]
+    Parse { path: PathBuf, reason: String },
+
+    #[error("invalid tool spec in config `{}`: {reason}", path.display())]
+    InvalidToolSpec { path: PathBuf, reason: String },
+}
+
+/// Load the `.runxrc` config file by walking up from `start_dir`.
+///
+/// Returns `Config::default()` if no config file is found.
+pub fn load_config(start_dir: &Path) -> Result<Config, ConfigError> {
+    match find_config(start_dir) {
+        Some(path) => parse_config_file(&path),
+        None => Ok(Config::default()),
+    }
+}
+
+/// Walk up from `start_dir` looking for `.runxrc`.
+fn find_config(start_dir: &Path) -> Option<PathBuf> {
+    let mut dir = start_dir.to_path_buf();
+    loop {
+        let candidate = dir.join(CONFIG_FILE_NAME);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        if !dir.pop() {
+            return None;
+        }
+    }
+}
+
+/// Parse a `.runxrc` TOML file into a `Config`.
+fn parse_config_file(path: &Path) -> Result<Config, ConfigError> {
+    let contents = std::fs::read_to_string(path).map_err(|e| ConfigError::Read {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+
+    let raw: RawConfig = toml::from_str(&contents).map_err(|e| ConfigError::Parse {
+        path: path.to_path_buf(),
+        reason: e.to_string(),
+    })?;
+
+    let tools = match raw.tools {
+        Some(specs) => specs
+            .into_iter()
+            .map(|s| {
+                s.parse::<ToolSpec>()
+                    .map_err(|e| ConfigError::InvalidToolSpec {
+                        path: path.to_path_buf(),
+                        reason: e,
+                    })
+            })
+            .collect::<Result<Vec<_>, _>>()?,
+        None => Vec::new(),
+    };
+
+    Ok(Config {
+        source: Some(path.to_path_buf()),
+        tools,
+        inherit_env: raw.inherit_env,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_find_config_in_current_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join(CONFIG_FILE_NAME);
+        std::fs::write(&config_path, "tools = [\"node@18\"]").unwrap();
+
+        let found = find_config(dir.path());
+        assert_eq!(found, Some(config_path));
+    }
+
+    #[test]
+    fn test_find_config_walks_up() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join(CONFIG_FILE_NAME);
+        std::fs::write(&config_path, "tools = [\"node@18\"]").unwrap();
+
+        let child = dir.path().join("subdir");
+        std::fs::create_dir(&child).unwrap();
+
+        let found = find_config(&child);
+        assert_eq!(found, Some(config_path));
+    }
+
+    #[test]
+    fn test_find_config_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let child = dir.path().join("a").join("b").join("c");
+        std::fs::create_dir_all(&child).unwrap();
+
+        // No .runxrc anywhere in the temp dir tree
+        let found = find_config(&child);
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn test_parse_full_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join(CONFIG_FILE_NAME);
+        std::fs::write(
+            &config_path,
+            r#"
+tools = ["node@18", "python@3.11"]
+inherit_env = true
+"#,
+        )
+        .unwrap();
+
+        let config = parse_config_file(&config_path).unwrap();
+        assert_eq!(config.source, Some(config_path));
+        assert_eq!(config.tools.len(), 2);
+        assert_eq!(config.tools[0].name, "node");
+        assert_eq!(config.tools[0].version.as_deref(), Some("18"));
+        assert_eq!(config.tools[1].name, "python");
+        assert_eq!(config.tools[1].version.as_deref(), Some("3.11"));
+        assert_eq!(config.inherit_env, Some(true));
+    }
+
+    #[test]
+    fn test_parse_tools_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join(CONFIG_FILE_NAME);
+        std::fs::write(&config_path, "tools = [\"go@1.21\"]\n").unwrap();
+
+        let config = parse_config_file(&config_path).unwrap();
+        assert_eq!(config.tools.len(), 1);
+        assert_eq!(config.tools[0].name, "go");
+        assert_eq!(config.inherit_env, None);
+    }
+
+    #[test]
+    fn test_parse_empty_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join(CONFIG_FILE_NAME);
+        std::fs::write(&config_path, "").unwrap();
+
+        let config = parse_config_file(&config_path).unwrap();
+        assert!(config.tools.is_empty());
+        assert_eq!(config.inherit_env, None);
+    }
+
+    #[test]
+    fn test_parse_inherit_env_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join(CONFIG_FILE_NAME);
+        std::fs::write(&config_path, "inherit_env = false\n").unwrap();
+
+        let config = parse_config_file(&config_path).unwrap();
+        assert!(config.tools.is_empty());
+        assert_eq!(config.inherit_env, Some(false));
+    }
+
+    #[test]
+    fn test_parse_malformed_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join(CONFIG_FILE_NAME);
+        std::fs::write(&config_path, "tools = [not valid toml").unwrap();
+
+        let err = parse_config_file(&config_path).unwrap_err();
+        assert!(matches!(err, ConfigError::Parse { .. }));
+        assert!(err.to_string().contains("failed to parse config"));
+    }
+
+    #[test]
+    fn test_parse_invalid_tool_spec() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join(CONFIG_FILE_NAME);
+        std::fs::write(&config_path, "tools = [\"@18\"]\n").unwrap();
+
+        let err = parse_config_file(&config_path).unwrap_err();
+        assert!(matches!(err, ConfigError::InvalidToolSpec { .. }));
+    }
+
+    #[test]
+    fn test_parse_tool_without_version() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join(CONFIG_FILE_NAME);
+        std::fs::write(&config_path, "tools = [\"node\"]\n").unwrap();
+
+        let config = parse_config_file(&config_path).unwrap();
+        assert_eq!(config.tools[0].name, "node");
+        assert_eq!(config.tools[0].version, None);
+    }
+
+    #[test]
+    fn test_load_config_no_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = load_config(dir.path()).unwrap();
+        assert!(config.source.is_none());
+        assert!(config.tools.is_empty());
+    }
+
+    #[test]
+    fn test_load_config_with_file() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(CONFIG_FILE_NAME), "tools = [\"node@20\"]\n").unwrap();
+
+        let config = load_config(dir.path()).unwrap();
+        assert!(config.source.is_some());
+        assert_eq!(config.tools.len(), 1);
+    }
+
+    #[test]
+    fn test_config_error_display() {
+        let err = ConfigError::Parse {
+            path: PathBuf::from("/tmp/.runxrc"),
+            reason: "unexpected token".to_string(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "failed to parse config `/tmp/.runxrc`: unexpected token"
+        );
+
+        let err = ConfigError::InvalidToolSpec {
+            path: PathBuf::from("/tmp/.runxrc"),
+            reason: "missing tool name".to_string(),
+        };
+        assert!(err.to_string().contains("invalid tool spec"));
+    }
+
+    #[test]
+    fn test_config_default() {
+        let config = Config::default();
+        assert!(config.source.is_none());
+        assert!(config.tools.is_empty());
+        assert_eq!(config.inherit_env, None);
+    }
+
+    #[test]
+    fn test_parse_unknown_key_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join(CONFIG_FILE_NAME);
+        std::fs::write(&config_path, "tols = [\"node@18\"]\n").unwrap();
+
+        let err = parse_config_file(&config_path).unwrap_err();
+        assert!(matches!(err, ConfigError::Parse { .. }));
+        assert!(err.to_string().contains("failed to parse config"));
+    }
+
+    #[test]
+    fn test_find_config_skips_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        // Create .runxrc as a directory, not a file
+        std::fs::create_dir(dir.path().join(CONFIG_FILE_NAME)).unwrap();
+
+        let found = find_config(dir.path());
+        assert!(found.is_none());
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,5 @@
 use crate::cache::CacheError;
+use crate::config::ConfigError;
 use crate::download::DownloadError;
 use crate::environment::EnvironmentError;
 use crate::executor::ExecutorError;
@@ -45,4 +46,12 @@ pub enum RunxError {
     /// A command execution error.
     #[error(transparent)]
     Executor(#[from] ExecutorError),
+
+    /// A config file error.
+    #[error(transparent)]
+    Config(#[from] ConfigError),
+
+    /// Failed to determine the current working directory.
+    #[error("cannot determine current directory: {0}")]
+    NoCwd(std::io::Error),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod cache;
 mod cli;
+mod config;
 mod download;
 mod environment;
 mod error;

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,8 +1,11 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+use std::env;
+
 use crate::cache::Cache;
 use crate::cli::{Cli, Command};
+use crate::config;
 use crate::download::download_and_install;
 use crate::environment::{Environment, TempDirs};
 use crate::error::RunxError;
@@ -27,11 +30,38 @@ pub async fn run(cli: Cli) -> Result<(), RunxError> {
             if cli.cmd.is_empty() {
                 return Err(RunxError::NoCommand);
             }
-            if cli.tools.is_empty() {
+
+            // Load .runxrc config and merge with CLI flags
+            let cwd = env::current_dir().map_err(RunxError::NoCwd)?;
+            let cfg = config::load_config(&cwd)?;
+
+            // CLI --with flags override config tools entirely; if no CLI tools, use config
+            let mut merged = cli;
+            if merged.tools.is_empty() {
+                merged.tools = cfg.tools;
+            }
+
+            // Config inherit_env is a default; CLI --inherit-env flag overrides.
+            // Since --inherit-env is a bool flag (true if passed, false if not),
+            // !merged.inherit_env reliably means "user did not pass --inherit-env".
+            if let Some(inherit) = cfg.inherit_env
+                && !merged.inherit_env
+            {
+                merged.inherit_env = inherit;
+            }
+
+            if merged.tools.is_empty() {
                 return Err(RunxError::NoTools);
             }
 
-            run_command(&cli).await?;
+            // Show config source in dry-run or verbose mode
+            if let Some(ref source) = cfg.source
+                && (merged.dry_run || merged.verbose)
+            {
+                eprintln!("Loaded config: {}", source.display());
+            }
+
+            run_command(&merged).await?;
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds `.runxrc` TOML config file support with auto-detection (walks up parent directories)
- Config format: `tools = ["node@18", "python@3.11"]` and `inherit_env = true`
- CLI `--with` flags override config tools; `--dry-run`/`--verbose` show loaded config path
- Unknown TOML keys are rejected via `deny_unknown_fields` to catch typos

## Acceptance Criteria
- [x] `.runxrc` auto-detected in current directory, then parent directories (walk up)
- [x] TOML format: `tools = ["node@18", "python@3.11"]`
- [x] CLI `--with` flags override config file values
- [x] Config file can also specify `inherit_env = true` and other defaults
- [x] Clear error messages for malformed config files
- [x] `runx --dry-run` shows which config file was loaded

## Test plan
- [x] 270 tests passing (16 new tests for config module)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features` clean (zero warnings)
- [x] Manual verification: config loading, dry-run output, parent directory walk-up

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)