### PR TITLE
feat: polish error messages, help text, and shell completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1401,6 +1410,7 @@ name = "runx"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "clap_complete",
  "ctrlc",
  "dirs",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 ctrlc = { version = "3", features = ["termination"] }
 dirs = "6"
 flate2 = "1"

--- a/README.md
+++ b/README.md
@@ -125,6 +125,21 @@ runx init --with node@18           # Non-interactive with specific tools
 runx init --force                  # Overwrite existing .runxrc
 ```
 
+### Shell completions
+
+Generate tab-completion scripts for your shell:
+
+```bash
+# Bash (add to ~/.bashrc)
+eval "$(runx completions bash)"
+
+# Zsh (add to ~/.zshrc)
+eval "$(runx completions zsh)"
+
+# Fish (add to ~/.config/fish/config.fish)
+runx completions fish | source
+```
+
 ## How It Works
 
 1. **Resolve** -- Queries upstream version APIs to resolve `node@18` to an exact version like `18.19.1`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::str::FromStr;
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 
 /// A tool specifier in the format `name` or `name@version`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -127,6 +127,9 @@ pub struct Cli {
 #[derive(Subcommand, Debug)]
 pub enum Command {
     /// Remove cached tool binaries to reclaim disk space
+    #[command(
+        after_help = "Examples:\n  runx clean                         Remove all cached binaries\n  runx clean --tool node             Remove only Node.js caches\n  runx clean --older-than 30d        Remove caches older than 30 days\n  runx clean -y                      Skip confirmation prompt"
+    )]
     Clean {
         /// Remove only caches for this tool
         #[arg(long, value_name = "NAME")]
@@ -142,6 +145,9 @@ pub enum Command {
     },
 
     /// List available tools and cached versions
+    #[command(
+        after_help = "Examples:\n  runx list                          Show all supported tools\n  runx list --cached                 Show cached versions with sizes\n  runx list node                     Show available Node.js versions"
+    )]
     List {
         /// Show only cached tool versions with sizes
         #[arg(long)]
@@ -152,6 +158,9 @@ pub enum Command {
     },
 
     /// Scaffold a .runxrc config file in the current directory
+    #[command(
+        after_help = "Examples:\n  runx init                          Interactive tool selection\n  runx init --with node@18           Non-interactive with specific tools\n  runx init --force                  Overwrite existing .runxrc"
+    )]
     Init {
         /// Tool to include (repeatable, e.g. --with node@18)
         #[arg(long = "with", value_name = "TOOL@VERSION")]
@@ -161,6 +170,23 @@ pub enum Command {
         #[arg(long)]
         force: bool,
     },
+
+    /// Generate shell completions for bash, zsh, or fish
+    #[command(
+        after_help = "Examples:\n  runx completions bash > ~/.bash_completion.d/runx\n  runx completions zsh > ~/.zfunc/_runx\n  runx completions fish > ~/.config/fish/completions/runx.fish"
+    )]
+    Completions {
+        /// Shell to generate completions for
+        shell: ShellType,
+    },
+}
+
+/// Supported shell types for completion generation.
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum ShellType {
+    Bash,
+    Zsh,
+    Fish,
 }
 
 #[cfg(test)]

--- a/src/download.rs
+++ b/src/download.rs
@@ -320,10 +320,14 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), DownloadError> {
 /// Errors that occur during download and extraction operations.
 #[derive(Debug, thiserror::Error)]
 pub enum DownloadError {
-    #[error("HTTP request failed for `{url}`: {source}")]
+    #[error(
+        "HTTP request failed for `{url}`: {source}\n  Check your network connection and try again."
+    )]
     Http { url: String, source: reqwest::Error },
 
-    #[error("HTTP {status} error for `{url}`")]
+    #[error(
+        "HTTP {status} error for `{url}`.\n  The download URL may be incorrect or the server may be down."
+    )]
     HttpStatus { url: String, status: u16 },
 
     #[error("I/O error at `{}`: {source}", path.display())]
@@ -416,10 +420,9 @@ mod tests {
             url: "https://example.com/file.tar.gz".to_string(),
             status: 404,
         };
-        assert_eq!(
-            err.to_string(),
-            "HTTP 404 error for `https://example.com/file.tar.gz`"
-        );
+        let msg = err.to_string();
+        assert!(msg.contains("HTTP 404 error for `https://example.com/file.tar.gz`"));
+        assert!(msg.contains("server may be down"));
 
         let err = DownloadError::ChecksumMismatch {
             expected: "aaa".to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -209,6 +209,51 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_completions_bash() {
+        let cli = Cli::try_parse_from(["runx", "completions", "bash"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Completions {
+                shell: crate::cli::ShellType::Bash
+            })
+        ));
+    }
+
+    #[test]
+    fn test_parse_completions_zsh() {
+        let cli = Cli::try_parse_from(["runx", "completions", "zsh"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Completions {
+                shell: crate::cli::ShellType::Zsh
+            })
+        ));
+    }
+
+    #[test]
+    fn test_parse_completions_fish() {
+        let cli = Cli::try_parse_from(["runx", "completions", "fish"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Completions {
+                shell: crate::cli::ShellType::Fish
+            })
+        ));
+    }
+
+    #[test]
+    fn test_parse_completions_missing_shell_rejected() {
+        let result = Cli::try_parse_from(["runx", "completions"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_completions_invalid_shell_rejected() {
+        let result = Cli::try_parse_from(["runx", "completions", "powershell"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn test_parse_unknown_flag_rejected() {
         let result = Cli::try_parse_from(["runx", "--unknown"]);
         assert!(result.is_err());

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -154,20 +154,28 @@ pub trait Provider {
 #[derive(Debug, thiserror::Error)]
 pub enum ProviderError {
     /// The requested tool is not supported.
-    #[error("unknown tool `{name}`. Supported tools: node, python, go, deno, bun")]
+    #[error(
+        "unknown tool `{name}`.\n  Supported tools: node, python, go, deno, bun\n  Run `runx list` to see all available tools."
+    )]
     UnknownTool { name: String },
 
     /// No version matched the given spec.
-    #[error("no {tool} version found matching `{spec}`")]
+    #[error(
+        "no {tool} version found matching `{spec}`.\n  Run `runx list {tool}` to see available versions."
+    )]
     VersionNotFound { tool: String, spec: String },
 
     /// The tool does not support this platform/architecture combination.
     #[allow(unused)]
-    #[error("{tool} does not support target `{target}`")]
+    #[error(
+        "{tool} does not support target `{target}`.\n  Run `runx list {tool}` to see supported platforms."
+    )]
     UnsupportedTarget { tool: String, target: String },
 
     /// Network or API error during version resolution.
-    #[error("failed to resolve {tool} version: {reason}")]
+    #[error(
+        "failed to resolve {tool} version: {reason}\n  Check your network connection and try again."
+    )]
     ResolutionFailed { tool: String, reason: String },
 }
 
@@ -209,7 +217,9 @@ mod tests {
             tool: "node".to_string(),
             spec: "99".to_string(),
         };
-        assert_eq!(err.to_string(), "no node version found matching `99`");
+        let msg = err.to_string();
+        assert!(msg.contains("no node version found matching `99`"));
+        assert!(msg.contains("runx list node"));
     }
 
     #[test]
@@ -218,10 +228,9 @@ mod tests {
             tool: "bun".to_string(),
             target: "Windows-x86_64".to_string(),
         };
-        assert_eq!(
-            err.to_string(),
-            "bun does not support target `Windows-x86_64`"
-        );
+        let msg = err.to_string();
+        assert!(msg.contains("bun does not support target `Windows-x86_64`"));
+        assert!(msg.contains("runx list bun"));
     }
 
     #[test]
@@ -230,10 +239,9 @@ mod tests {
             tool: "python".to_string(),
             reason: "network timeout".to_string(),
         };
-        assert_eq!(
-            err.to_string(),
-            "failed to resolve python version: network timeout"
-        );
+        let msg = err.to_string();
+        assert!(msg.contains("failed to resolve python version: network timeout"));
+        assert!(msg.contains("Check your network connection"));
     }
 
     #[test]

--- a/src/run.rs
+++ b/src/run.rs
@@ -30,6 +30,9 @@ pub async fn run(cli: Cli) -> Result<(), RunxError> {
         Some(Command::Init { tools, force }) => {
             crate::init::run(&tools, force)?;
         }
+        Some(Command::Completions { shell }) => {
+            generate_completions(shell);
+        }
         None => {
             if cli.cmd.is_empty() {
                 return Err(RunxError::NoCommand);
@@ -249,6 +252,21 @@ async fn run_command(cli: &Cli) -> Result<(), RunxError> {
     }
 
     Ok(())
+}
+
+/// Generate shell completions and print to stdout.
+fn generate_completions(shell: crate::cli::ShellType) {
+    use clap::CommandFactory;
+    use clap_complete::Shell;
+
+    let shell = match shell {
+        crate::cli::ShellType::Bash => Shell::Bash,
+        crate::cli::ShellType::Zsh => Shell::Zsh,
+        crate::cli::ShellType::Fish => Shell::Fish,
+    };
+
+    let mut cmd = Cli::command();
+    clap_complete::generate(shell, &mut cmd, "runx", &mut std::io::stdout());
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Adds actionable suggestions to all error messages (network failures, unknown tools, version not found)
- Adds per-subcommand `--help` examples for clean, list, init, and completions
- Adds `runx completions bash|zsh|fish` for shell completion generation via clap_complete
- Updates error display tests to validate suggestion text

## Acceptance Criteria
- [x] User-friendly error messages with actionable suggestions
- [x] clap help text includes usage examples for each subcommand
- [x] Shell completion generation: bash, zsh, fish via clap_complete
- [x] `runx --version` shows version info (already worked via clap)
- [x] Consistent output formatting across all commands

## Test plan
- [x] 294 tests passing (5 new tests for completions parsing)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features` clean (zero warnings)
- [x] Manual verification of `runx completions bash`, `runx clean --help`, error messages

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)