### PR TITLE
feat: add auto-update for cached tools

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -193,6 +193,15 @@ pub enum Command {
         tool: ToolSpec,
     },
 
+    /// Update cached tools to the latest patch version
+    #[command(
+        after_help = "Examples:\n  runx update                        Update all cached tools\n  runx update node                   Update only Node.js"
+    )]
+    Update {
+        /// Specific tool to update (e.g. node)
+        tool: Option<ToolSpec>,
+    },
+
     /// Generate shell completions for bash, zsh, or fish
     #[command(
         after_help = "Examples:\n  runx completions bash > ~/.bash_completion.d/runx\n  runx completions zsh > ~/.zfunc/_runx\n  runx completions fish > ~/.config/fish/completions/runx.fish"

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod list;
 mod platform;
 mod provider;
 mod run;
+mod update;
 mod version;
 
 use clap::Parser;

--- a/src/run.rs
+++ b/src/run.rs
@@ -36,6 +36,9 @@ pub async fn run(cli: Cli) -> Result<(), RunxError> {
         Some(Command::Uninstall { tool }) => {
             crate::install::uninstall(&tool)?;
         }
+        Some(Command::Update { tool }) => {
+            crate::update::run(tool, cli.dry_run).await?;
+        }
         Some(Command::Completions { shell }) => {
             generate_completions(shell);
         }

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,0 +1,115 @@
+use crate::cache::Cache;
+use crate::cli::ToolSpec;
+use crate::download::download_and_install;
+use crate::error::RunxError;
+use crate::platform::Target;
+use crate::provider::{self, ProviderError};
+use crate::version::VersionSpec;
+
+/// Execute the `runx update` subcommand.
+pub async fn run(tool: Option<ToolSpec>, dry_run: bool) -> Result<(), RunxError> {
+    let cache = Cache::new()?;
+    let target = Target::detect().map_err(RunxError::UnsupportedPlatform)?;
+    let cached_tools = cache.list_cached()?;
+
+    if cached_tools.is_empty() {
+        println!("No cached tools to update.");
+        return Ok(());
+    }
+
+    let tool_filter = tool.as_ref().map(|t| t.name.as_str());
+    let mut updated = 0;
+    let mut checked = 0;
+
+    for cached in &cached_tools {
+        if let Some(filter) = tool_filter
+            && cached.name != filter
+        {
+            continue;
+        }
+
+        // Check if this is a known provider
+        let provider = match provider::get_provider(&cached.name) {
+            Ok(p) => p,
+            Err(_) => continue, // Skip unknown tools in cache
+        };
+
+        for version_str in &cached.versions {
+            let current: semver::Version = match version_str.parse() {
+                Ok(v) => v,
+                Err(_) => continue, // Skip unparseable versions
+            };
+
+            // Resolve the same major.minor to find the latest patch
+            let spec = VersionSpec::MajorMinor(current.major, current.minor);
+            let latest = match provider.resolve_version(&spec, &target) {
+                Ok(v) => v,
+                Err(ProviderError::ResolutionFailed { .. }) => continue,
+                Err(e) => return Err(e.into()),
+            };
+
+            checked += 1;
+
+            if latest > current {
+                if dry_run {
+                    println!("  {} {current} → {latest} (update available)", cached.name);
+                } else {
+                    eprint!("Updating {} {current} → {latest}...", cached.name);
+
+                    let install_dir = cache.install_path(provider.name(), &latest, &target);
+                    if !cache.is_cached(provider.name(), &latest, &target) {
+                        let url = provider.download_url(&latest, &target)?;
+                        let format = provider.archive_format(&target);
+                        download_and_install(&url, &install_dir, format, None, true).await?;
+                    }
+                    eprintln!(" done");
+
+                    println!("  {} {current} → {latest}", cached.name);
+                    updated += 1;
+                }
+            }
+        }
+    }
+
+    if dry_run {
+        if checked > 0 && updated == 0 {
+            println!("All cached tools are up to date.");
+        }
+    } else if updated == 0 {
+        println!("All cached tools are up to date.");
+    } else {
+        println!(
+            "\nUpdated {updated} tool{}. Old versions kept in cache.",
+            if updated == 1 { "" } else { "s" }
+        );
+    }
+
+    if let Some(ref spec) = tool
+        && tool_filter.is_some()
+        && !cached_tools.iter().any(|t| t.name == spec.name)
+    {
+        println!("No cached versions of {}.", spec.name);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_update_empty_cache() {
+        // Should handle empty cache gracefully
+        // (uses real ~/.runx/cache which may or may not be empty)
+        // Just verify it doesn't panic
+        let _ = run(
+            Some(ToolSpec {
+                name: "nonexistent-tool-xyz".to_string(),
+                version: None,
+            }),
+            true,
+        )
+        .await;
+    }
+}


### PR DESCRIPTION
## Summary
- `runx update` checks cached tools for newer patch versions and downloads them
- `runx update node` updates a specific tool only
- `runx --dry-run update` previews without downloading
- Old versions kept in cache

## Test plan
- [x] 311 tests passing
- [x] Clippy and fmt clean

Closes #39