### PR TITLE
feat: add post-install hooks to plugin system

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -47,6 +47,19 @@ pub struct PluginManifest {
     #[serde(default)]
     #[allow(dead_code)] // Reserved for future shebang integration with plugins
     pub interpreter: Vec<String>,
+    /// Shell command to run after extraction (e.g., "./install.sh --prefix={install_dir}").
+    /// Supports placeholders: {install_dir}, {version}, {os}, {arch}.
+    /// Runs with CWD set to the install directory.
+    #[serde(default)]
+    pub post_install: Option<String>,
+    /// Timeout for post_install in seconds (default: 300 = 5 minutes).
+    #[serde(default = "default_post_install_timeout")]
+    #[allow(dead_code)] // Reserved for future timeout enforcement
+    pub post_install_timeout: u64,
+}
+
+fn default_post_install_timeout() -> u64 {
+    300
 }
 
 fn default_archive_format() -> String {
@@ -64,6 +77,18 @@ impl PluginManifest {
             .replace("{version}", &version.to_string())
             .replace("{os}", &target.platform.to_string().to_lowercase())
             .replace("{arch}", &target.arch.to_string())
+    }
+
+    /// Expand placeholders including {install_dir}.
+    fn expand_with_dir(
+        &self,
+        template: &str,
+        version: &semver::Version,
+        target: &Target,
+        install_dir: &Path,
+    ) -> String {
+        self.expand(template, version, target)
+            .replace("{install_dir}", &install_dir.display().to_string())
     }
 }
 
@@ -123,6 +148,18 @@ impl Provider for PluginProvider {
 
     fn env_vars(&self, _install_dir: &Path) -> HashMap<String, String> {
         HashMap::new()
+    }
+
+    fn post_install_command(
+        &self,
+        version: &semver::Version,
+        target: &Target,
+        install_dir: &Path,
+    ) -> Option<String> {
+        self.manifest.post_install.as_ref().map(|cmd| {
+            self.manifest
+                .expand_with_dir(cmd, version, target, install_dir)
+        })
     }
 }
 
@@ -302,6 +339,8 @@ download_url = "https://example.com/{version}/mytool.tar.gz"
             archive_format: "tar.xz".to_string(),
             bin_path: "zig-{os}-{arch}-{version}".to_string(),
             interpreter: vec![],
+            post_install: None,
+            post_install_timeout: 300,
         };
 
         let version = semver::Version::new(0, 11, 0);
@@ -338,6 +377,8 @@ download_url = "https://example.com/{version}/mytool.tar.gz"
             archive_format: fmt.to_string(),
             bin_path: "bin".to_string(),
             interpreter: vec![],
+            post_install: None,
+            post_install_timeout: 300,
         };
 
         let target = Target::new(
@@ -371,5 +412,118 @@ download_url = "https://example.com/{version}/mytool.tar.gz"
     fn test_list_plugins_no_dir() {
         let result = list_plugins();
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_plugin_manifest_with_post_install() {
+        let toml_str = r#"
+name = "rust"
+download_url = "https://static.rust-lang.org/dist/rust-{version}-{arch}-{os}.tar.gz"
+post_install = "./install.sh --prefix={install_dir} --without=rust-docs"
+post_install_timeout = 600
+"#;
+        let manifest: PluginManifest = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            manifest.post_install.as_deref(),
+            Some("./install.sh --prefix={install_dir} --without=rust-docs")
+        );
+        assert_eq!(manifest.post_install_timeout, 600);
+    }
+
+    #[test]
+    fn test_plugin_manifest_default_post_install() {
+        let toml_str = r#"
+name = "simple"
+download_url = "https://example.com/{version}/tool.tar.gz"
+"#;
+        let manifest: PluginManifest = toml::from_str(toml_str).unwrap();
+        assert!(manifest.post_install.is_none());
+        assert_eq!(manifest.post_install_timeout, 300);
+    }
+
+    #[test]
+    fn test_plugin_expand_with_install_dir() {
+        let manifest = PluginManifest {
+            name: "rust".to_string(),
+            aliases: vec![],
+            description: String::new(),
+            download_url: String::new(),
+            archive_format: "tar.gz".to_string(),
+            bin_path: "bin".to_string(),
+            interpreter: vec![],
+            post_install: Some("./install.sh --prefix={install_dir}".to_string()),
+            post_install_timeout: 300,
+        };
+
+        let version = semver::Version::new(1, 82, 0);
+        let target = Target::new(
+            crate::platform::Platform::Linux,
+            crate::platform::Arch::X86_64,
+        );
+
+        let expanded = manifest.expand_with_dir(
+            manifest.post_install.as_ref().unwrap(),
+            &version,
+            &target,
+            Path::new("/home/user/.runx/cache/rust/1.82.0"),
+        );
+        assert_eq!(
+            expanded,
+            "./install.sh --prefix=/home/user/.runx/cache/rust/1.82.0"
+        );
+    }
+
+    #[test]
+    fn test_plugin_provider_post_install_command() {
+        let manifest = PluginManifest {
+            name: "rust".to_string(),
+            aliases: vec![],
+            description: String::new(),
+            download_url: String::new(),
+            archive_format: "tar.gz".to_string(),
+            bin_path: "bin".to_string(),
+            interpreter: vec![],
+            post_install: Some("./install.sh --prefix={install_dir}".to_string()),
+            post_install_timeout: 300,
+        };
+
+        let provider = PluginProvider { manifest };
+        let version = semver::Version::new(1, 82, 0);
+        let target = Target::new(
+            crate::platform::Platform::Linux,
+            crate::platform::Arch::X86_64,
+        );
+
+        let cmd = provider.post_install_command(&version, &target, Path::new("/cache/rust/1.82.0"));
+        assert!(cmd.is_some());
+        assert!(cmd.unwrap().contains("--prefix=/cache/rust/1.82.0"));
+    }
+
+    #[test]
+    fn test_plugin_provider_no_post_install() {
+        let manifest = PluginManifest {
+            name: "zig".to_string(),
+            aliases: vec![],
+            description: String::new(),
+            download_url: String::new(),
+            archive_format: "tar.gz".to_string(),
+            bin_path: "bin".to_string(),
+            interpreter: vec![],
+            post_install: None,
+            post_install_timeout: 300,
+        };
+
+        let provider = PluginProvider { manifest };
+        let version = semver::Version::new(0, 11, 0);
+        let target = Target::new(
+            crate::platform::Platform::Linux,
+            crate::platform::Arch::X86_64,
+        );
+
+        assert!(
+            provider
+                .post_install_command(&version, &target, Path::new("/cache"))
+                .is_none()
+        );
     }
 }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -206,6 +206,20 @@ pub trait Provider {
     fn temp_env_dirs(&self) -> Vec<&'static str> {
         Vec::new()
     }
+
+    /// Return an optional post-install command to run after extraction.
+    ///
+    /// The command runs with CWD set to `install_dir`. Placeholders
+    /// `{install_dir}`, `{version}`, `{os}`, `{arch}` are expanded.
+    /// Default: no post-install step.
+    fn post_install_command(
+        &self,
+        _version: &semver::Version,
+        _target: &Target,
+        _install_dir: &std::path::Path,
+    ) -> Option<String> {
+        None
+    }
 }
 
 /// Errors that occur during provider operations.

--- a/src/run.rs
+++ b/src/run.rs
@@ -226,6 +226,20 @@ async fn run_command(cli: &Cli) -> Result<(), RunxError> {
         }
     }
 
+    // Phase 2b: Run post-install hooks for freshly downloaded tools
+    for tool in &resolved_tools {
+        if !tool.cached
+            && let Some(cmd) =
+                tool.provider
+                    .post_install_command(&tool.version, &target, &tool.install_dir)
+        {
+            if !cli.quiet {
+                eprintln!("Running post-install for {}...", tool.name);
+            }
+            run_post_install(&cmd, &tool.install_dir, &tool.name)?;
+        }
+    }
+
     // Phase 3: Collect bin paths, env vars, and temp dirs
     let mut all_bin_dirs: Vec<PathBuf> = Vec::new();
     let mut all_tool_env_vars: HashMap<String, String> = HashMap::new();
@@ -272,6 +286,37 @@ async fn run_command(cli: &Cli) -> Result<(), RunxError> {
     let code = executor::exit_code(&status);
     if code != 0 {
         std::process::exit(code);
+    }
+
+    Ok(())
+}
+
+/// Run a post-install shell command in the given directory.
+fn run_post_install(
+    command: &str,
+    install_dir: &std::path::Path,
+    tool_name: &str,
+) -> Result<(), RunxError> {
+    let shell = if cfg!(windows) { "cmd" } else { "sh" };
+    let flag = if cfg!(windows) { "/c" } else { "-c" };
+
+    let status = std::process::Command::new(shell)
+        .args([flag, command])
+        .current_dir(install_dir)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .status()
+        .map_err(|e| {
+            RunxError::Plugin(format!("post-install for {tool_name} failed to start: {e}"))
+        })?;
+
+    if !status.success() {
+        // Clean up the install dir to prevent a corrupt cache entry
+        let _ = std::fs::remove_dir_all(install_dir);
+        return Err(RunxError::Plugin(format!(
+            "post-install for {tool_name} failed with exit code {}.\n  Command: {command}\n  The install directory has been cleaned up.",
+            status.code().unwrap_or(-1)
+        )));
     }
 
     Ok(())


### PR DESCRIPTION
## Summary
- Plugins can now specify `post_install` shell commands that run after extraction
- Supports `{install_dir}`, `{version}`, `{os}`, `{arch}` placeholders
- On failure, cleans up install dir and reports clear error
- Added `post_install_command()` to Provider trait with default no-op
- Unlocks Rust, Java, Ruby, Swift as plugin-based providers

## Test plan
- [x] 343 tests passing (5 new for post-install)
- [x] Clippy and fmt clean

Closes #46