### PR TITLE
feat: support cleaning specific tool versions (runx clean java@21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,7 +586,9 @@ runx list                      # All tools and cache status
 runx list --cached             # Cached versions with disk sizes
 runx list --cached java        # Cached versions for a specific tool
 runx clean                     # Remove everything (with confirmation)
-runx clean --tool node         # Remove only Node.js caches
+runx clean node                # Remove all Node.js caches
+runx clean java@21             # Remove only Java 21.x versions
+runx clean java@21.0.10        # Remove exact version
 runx clean --older-than 30d    # Remove stale versions
 ```
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -79,6 +79,62 @@ impl Cache {
         Ok(size)
     }
 
+    /// Remove cached versions of a tool matching a version spec.
+    ///
+    /// Uses `VersionSpec` matching: `Major(21)` removes all `21.x.x`,
+    /// `MajorMinor(21, 0)` removes all `21.0.x`, `Exact` removes one version.
+    pub fn clean_version(
+        &self,
+        tool: &str,
+        spec: &crate::version::VersionSpec,
+    ) -> Result<u64, CacheError> {
+        let tool_dir = self.root.join(tool);
+        if !tool_dir.exists() {
+            return Ok(0);
+        }
+
+        let versions = self.list_versions(tool)?;
+        let mut freed = 0u64;
+
+        for ver_str in &versions {
+            let Ok(ver) = ver_str.parse::<semver::Version>() else {
+                continue;
+            };
+            if spec.matches(&ver) {
+                let ver_dir = tool_dir.join(ver_str);
+                freed += dir_size(&ver_dir);
+                std::fs::remove_dir_all(&ver_dir).map_err(|e| CacheError::Io {
+                    path: ver_dir,
+                    source: e,
+                })?;
+            }
+        }
+
+        // Clean up empty tool directory
+        if self.list_versions(tool)?.is_empty() && tool_dir.exists() {
+            let _ = std::fs::remove_dir(&tool_dir);
+        }
+
+        Ok(freed)
+    }
+
+    /// List cached versions matching a version spec (for dry-run display).
+    pub fn matching_versions(
+        &self,
+        tool: &str,
+        spec: &crate::version::VersionSpec,
+    ) -> Result<Vec<String>, CacheError> {
+        let versions = self.list_versions(tool)?;
+        Ok(versions
+            .into_iter()
+            .filter(|v| {
+                v.parse::<semver::Version>()
+                    .map(|ver| spec.matches(&ver))
+                    .unwrap_or(false)
+            })
+            .collect())
+    }
+
     /// Remove all cached tools.
     pub fn clean_all(&self) -> Result<u64, CacheError> {
         if !self.root.exists() {

--- a/src/clean.rs
+++ b/src/clean.rs
@@ -62,15 +62,57 @@ fn clean_all(cache: &Cache, yes: bool, dry_run: bool) -> Result<(), RunxError> {
     Ok(())
 }
 
-/// Remove all cached versions of a specific tool.
+/// Remove cached versions of a specific tool, optionally filtered by version.
 fn clean_tool(cache: &Cache, spec: &ToolSpec, yes: bool, dry_run: bool) -> Result<(), RunxError> {
-    if spec.version.is_some() {
-        eprintln!(
-            "Warning: version specifier ignored. `clean --tool {}` removes all cached versions of {}.",
-            spec, spec.name
+    // If a version is specified, clean only matching versions
+    if let Some(ref version_str) = spec.version {
+        let version_spec = spec.version_spec()?;
+        let matching = cache.matching_versions(&spec.name, &version_spec)?;
+
+        if matching.is_empty() {
+            println!(
+                "No cached versions of {} matching {}.",
+                spec.name, version_str
+            );
+            return Ok(());
+        }
+
+        let count = matching.len();
+        let verb = if dry_run {
+            "Would remove"
+        } else {
+            "Will remove"
+        };
+        println!(
+            "{verb} {count} version{} of {}:",
+            if count == 1 { "" } else { "s" },
+            spec.name
         );
+        for v in &matching {
+            println!("  {}@{}", spec.name, v);
+        }
+
+        if dry_run {
+            return Ok(());
+        }
+
+        if !yes
+            && !confirm(&format!(
+                "Remove {} matching version{}?",
+                count,
+                if count == 1 { "" } else { "s" }
+            ))?
+        {
+            println!("Aborted.");
+            return Ok(());
+        }
+
+        let freed = cache.clean_version(&spec.name, &version_spec)?;
+        println!("Freed {}.", format_size(freed));
+        return Ok(());
     }
 
+    // No version specified — remove all versions of this tool
     let tools = cache.list_cached()?;
     let tool = tools.iter().find(|t| t.name == spec.name);
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -145,11 +145,11 @@ pub struct Cli {
 pub enum Command {
     /// Remove cached tool binaries to reclaim disk space
     #[command(
-        after_help = "Examples:\n  runx clean                         Remove all cached binaries\n  runx clean --tool node             Remove only Node.js caches\n  runx clean --older-than 30d        Remove caches older than 30 days\n  runx clean -y                      Skip confirmation prompt"
+        after_help = "Examples:\n  runx clean                         Remove all cached binaries\n  runx clean java                    Remove all Java caches\n  runx clean java@21                 Remove Java 21.x caches only\n  runx clean java@21.0.10            Remove exact version\n  runx clean --older-than 30d        Remove caches older than 30 days\n  runx clean -y                      Skip confirmation prompt"
     )]
     Clean {
-        /// Remove only caches for this tool
-        #[arg(long, value_name = "NAME")]
+        /// Tool (and optional version) to clean, e.g. `java`, `java@21`, `node@18.19.1`
+        #[arg(value_name = "TOOL[@VERSION]")]
         tool: Option<ToolSpec>,
 
         /// Remove caches older than this duration (e.g. 30d, 7d)

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,8 +128,7 @@ mod tests {
 
     #[test]
     fn test_parse_clean_with_args() {
-        let cli = Cli::try_parse_from(["runx", "clean", "--tool", "node", "--older-than", "30d"])
-            .unwrap();
+        let cli = Cli::try_parse_from(["runx", "clean", "node", "--older-than", "30d"]).unwrap();
         let Some(Command::Clean {
             tool,
             older_than,

--- a/src/run.rs
+++ b/src/run.rs
@@ -466,8 +466,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_run_clean_with_args() {
-        let cli = Cli::try_parse_from(["runx", "clean", "--tool", "node", "--older-than", "30d"])
-            .unwrap();
+        let cli = Cli::try_parse_from(["runx", "clean", "node", "--older-than", "30d"]).unwrap();
         assert!(run(cli).await.is_ok());
     }
 


### PR DESCRIPTION
## Summary

- `runx clean java@21` removes only Java 21.x cached versions
- `runx clean java@21.0.10` removes exact version
- `runx clean node` removes all Node.js caches (existing behavior, now positional)
- Supports `--dry-run` and `-y` confirmation skip
- Cleans up empty tool directories after version removal

## Test plan

- [x] `cargo fmt --check` — passes
- [x] `cargo clippy` — 0 warnings
- [x] `cargo test` — 479 passing
- [ ] Manual: `runx clean java@21` with 2 Java versions cached
- [ ] Manual: `runx --dry-run clean java@21` shows what would be deleted

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)